### PR TITLE
fix: initial guess explanation correction

### DIFF
--- a/contracts/PRBMath.sol
+++ b/contracts/PRBMath.sol
@@ -601,7 +601,7 @@ library PRBMath {
             return 0;
         }
 
-        // Set the initial guess to the closest power of two that is higher than x.
+        // Set the initial guess to the closest power of two that is at least sqrt(x).
         uint256 xAux = uint256(x);
         result = 1;
         if (xAux >= 0x100000000000000000000000000000000) {


### PR DESCRIPTION
i believe this explanation is incorrect, see an explanation of Newton's Method (which the babylonian method uses) in Hacker's Delight for details

<img width="1033" alt="Screen Shot 2021-12-24 at 2 50 11 PM" src="https://user-images.githubusercontent.com/26209401/147373730-e36e9b75-6957-451d-b101-ebb6ac5a29ee.png">
